### PR TITLE
feat: Enhance roster management functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,31 +399,42 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Team Management</h5>
+          <h5 class="modal-title">Team Roster Management</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
-          <div class="row">
-            <div class="col-12 col-md-8">
-              <div class="input-group mb-3">
-                <input type="text" id="newPlayerName" class="form-control" placeholder="New Player Name">
-                <button class="btn btn-danger" id="addPlayerBtn">Add Player</button>
-              </div>
-            </div>
+          <h5>Add New Player</h5>
+          <div class="input-group mb-3">
+            <input type="text" id="newPlayerName" class="form-control" placeholder="Enter player name">
+            <button class="btn btn-primary" id="addPlayerBtn">Add Single Player</button>
           </div>
-          <div class="row">
-            <div class="col-12">
-              <table class="table table-striped">
-                <thead>
-                  <tr>
-                    <th>Player Name</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody id="rosterList"></tbody>
-              </table>
-            </div>
+
+          <hr>
+
+          <h5>Bulk Add Players</h5>
+          <div class="mb-3">
+            <label for="bulkPlayerNames" class="form-label">Paste names (comma or new-line separated):</label>
+            <textarea id="bulkPlayerNames" class="form-control mb-2" rows="3" placeholder="e.g. Player One, Player Two&#x0a;Player Three"></textarea>
+            <button id="addPlayersBulkBtn" class="btn btn-info w-100">Add Players from List</button>
           </div>
+
+          <hr>
+
+          <h5>Current Roster</h5>
+          <div class="table-responsive" style="max-height: 300px; overflow-y: auto;">
+            <table class="table table-striped table-sm">
+              <thead>
+                <tr>
+                  <th>Player Name</th>
+                  <th class="text-end">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="rosterList"></tbody>
+            </table>
+          </div>
+
+          <hr class="my-3">
+          <button id="clearRosterBtn" class="btn btn-danger w-100">Clear All Players</button>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>


### PR DESCRIPTION
This commit introduces several improvements to the team roster management:

- **Edit Player Names:** You can now edit existing player names directly within the roster management modal. The changes are reflected in the player list and any dropdowns where players are selected (e.g., goal scorer, assist).
- **Bulk Add Players:** A new feature allows you to add multiple players at once by pasting a comma or newline-separated list of names. Input is validated for duplicates, length, and empty strings.
- **Clear Roster:** You can now clear the entire roster with a confirmation step. This will remove all players from the list and local storage.
- **Improved Modal Layout:** The Roster Management modal has been reorganized for better usability with clear sections for adding single players, bulk adding, and viewing the current roster. The player list is now scrollable to accommodate longer rosters.

All new functionalities include appropriate notifications for success, warnings, and errors. Existing functionalities like adding and removing single players have been maintained and tested alongside the new features.