### PR TITLE
feat: Allow shirt numbers for players

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,9 +404,18 @@
         </div>
         <div class="modal-body">
           <h5>Add New Player</h5>
-          <div class="input-group mb-3">
-            <input type="text" id="newPlayerName" class="form-control" placeholder="Enter player name">
-            <button class="btn btn-primary" id="addPlayerBtn">Add Single Player</button>
+          <div class="row mb-3">
+            <div class="col">
+                <input type="text" class="form-control" id="newPlayerName" placeholder="Enter player name">
+            </div>
+            <div class="col-auto">
+                <input type="number" class="form-control" id="newPlayerShirtNumber" placeholder="Shirt #" style="width: 100px;">
+            </div>
+            <div class="col-auto">
+                <button class="btn btn-primary" id="addPlayerBtn">
+                    <i class="fas fa-plus"></i> Add Player
+                </button>
+            </div>
           </div>
 
           <hr>
@@ -426,6 +435,7 @@
               <thead>
                 <tr>
                   <th>Player Name</th>
+                  <th>Shirt #</th>
                   <th class="text-end">Actions</th>
                 </tr>
               </thead>


### PR DESCRIPTION
This commit introduces the ability to assign, edit, and view shirt numbers for players in the roster.

Key changes:

- Player data structure in `js/roster.js` updated to store objects containing both name and shirt number (e.g., `{ name: "Player Name", shirtNumber: 10 }`).
- Existing rosters stored as arrays of strings in localStorage will be automatically migrated to the new object format on load.
- The roster management modal in `index.html` has been updated:
    - An input field for shirt numbers has been added to the "Add Player" form.
    - The roster list now displays a "Shirt #" column.
- Player editing functionality in `js/roster.js` now uses the modal's input fields for both name and shirt number, replacing the previous `prompt()`-based editing.
- The "Add Player" button dynamically changes to "Save Changes" when editing a player.
- Input validation for shirt numbers (must be a number if provided) and player names (max length, uniqueness) is in place.
- Bulk add functionality remains focused on names; shirt numbers can be added individually via the edit feature.
- Dropdown lists for goal scorers and assists remain populated with player names for compatibility with existing game logic.