### PR TITLE
Fix: Default roster displays when roster is empty

### DIFF
--- a/js/roster.js
+++ b/js/roster.js
@@ -34,8 +34,8 @@ const RosterManager = (function() {
         return getDefaultRoster();
       }
 
-      if (parsedRoster.length === 0) {
-        return []; // Valid empty roster
+      if (parsedRoster.length === 0) { // If the stored roster is empty
+        return getDefaultRoster(); // Load default roster
       }
 
       let processedRoster = [];


### PR DESCRIPTION
Previously, if the roster in local storage was an empty array `[]`, the `RosterManager.loadRoster()` function would return this empty array instead of loading the default roster. This meant that if you cleared your roster, the default players would not reappear until local storage was manually cleared or an invalid roster was somehow saved.

This commit modifies `RosterManager.loadRoster()` in `js/roster.js` to call `getDefaultRoster()` when `parsedRoster.length === 0`. This ensures that the default roster is displayed if the currently stored roster is empty, providing a more user-friendly experience.

Testing included:
- Verifying default roster appears after clearing.
- Verifying default roster appears on initial load (simulated by clearing local storage).
- Verifying adding single and bulk players still works as expected.