### PR TITLE
Feat: Implement dedicated modal for editing player name and shirt number

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,36 @@
   </div>
 <!-- END Roster Modal -->
 
+<!-- Edit Player Modal -->
+<div class="modal fade" id="editPlayerModal" tabindex="-1" aria-labelledby="editPlayerModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editPlayerModalLabel">Edit Player</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="editPlayerForm">
+          <input type="hidden" id="editPlayerOldName" name="editPlayerOldName">
+          <div class="mb-3">
+            <label for="editPlayerName" class="form-label">Player Name</label>
+            <input type="text" class="form-control" id="editPlayerName" name="editPlayerName" required>
+          </div>
+          <div class="mb-3">
+            <label for="editPlayerShirtNumber" class="form-label">Shirt Number (0-99, blank for none)</label>
+            <input type="number" class="form-control" id="editPlayerShirtNumber" name="editPlayerShirtNumber" min="0" max="99">
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- END Edit Player Modal -->
+
 <!--Confirm Reset Modal-->
 <div class="modal fade" id="resetConfirmModal" data-bs-backdrop="static" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">

--- a/js/roster.js
+++ b/js/roster.js
@@ -491,35 +491,40 @@ const RosterManager = (function() {
             const playerToEdit = roster.find(p => p.name === playerName);
             if (!playerToEdit) return;
 
-            const newName = prompt(`Enter new name for ${playerName}:`, playerName);
-            if (newName !== null && newName.trim() !== '') {
-              const currentShirtNumber = playerToEdit.shirtNumber !== null ? playerToEdit.shirtNumber : '';
-              const newShirtNumberStr = prompt(`Enter new shirt number for ${newName.trim()} (leave blank for no number):`, currentShirtNumber);
+            // Populate and show the edit player modal
+            document.getElementById('editPlayerOldName').value = playerToEdit.name;
+            document.getElementById('editPlayerName').value = playerToEdit.name;
+            document.getElementById('editPlayerShirtNumber').value = playerToEdit.shirtNumber !== null ? playerToEdit.shirtNumber : '';
 
-              // newShirtNumberStr could be null if user cancels prompt, or empty string
-              // parseInt will handle empty string as NaN, which is fine for validation in editPlayer
-              this.editPlayer(playerName, newName.trim(), newShirtNumberStr);
+            const editModalElement = document.getElementById('editPlayerModal');
+            if (editModalElement) {
+              const editModal = bootstrap.Modal.getInstance(editModalElement) || new bootstrap.Modal(editModalElement);
+              editModal.show();
             }
           }
         });
       }
 
-      // Open roster modal event listener
-      // This event listener might be in script.js or elsewhere if 'openRosterModalBtn' is a global button.
-      // For now, assuming it's specific to this modal's context or handled externally.
-      // If openRosterModalBtn is indeed part of this component's controlled elements:
-      // if (openRosterModalBtn) {
-      //   openRosterModalBtn.addEventListener('click', () => {
-      //     const rosterModalElement = document.getElementById('rosterModal');
-      //     if (rosterModalElement) {
-      //       const rosterModal = bootstrap.Modal.getInstance(rosterModalElement) || new bootstrap.Modal(rosterModalElement);
-      //       rosterModal.show();
-      //       // Optionally clear inputs when modal opens
-      //       if(newPlayerNameInput) newPlayerNameInput.value = '';
-      //       if(newPlayerShirtNumberInput) newPlayerShirtNumberInput.value = '';
-      //     }
-      //   });
-      // }
+      // Event listener for the edit player form submission
+      const editPlayerForm = document.getElementById('editPlayerForm');
+      if (editPlayerForm) {
+        editPlayerForm.addEventListener('submit', (e) => {
+          e.preventDefault();
+          const oldName = document.getElementById('editPlayerOldName').value;
+          const newName = document.getElementById('editPlayerName').value.trim();
+          const newShirtNumber = document.getElementById('editPlayerShirtNumber').value; // string or empty
+
+          if (this.editPlayer(oldName, newName, newShirtNumber)) {
+            const editModalElement = document.getElementById('editPlayerModal');
+            const editModal = bootstrap.Modal.getInstance(editModalElement);
+            if (editModal) {
+              editModal.hide();
+            }
+          }
+          // If editPlayer returns false (due to validation failure), the modal remains open
+          // and the RosterManager.editPlayer function would have shown a notification.
+        });
+      }
     }
   };
 })();


### PR DESCRIPTION
- Added a new Bootstrap modal in `index.html` for editing player details.
- Updated `js/roster.js` to populate this modal with the selected player's current name and shirt number when 'Edit' is clicked.
- Implemented form submission handling for the new modal to save changes using the existing `RosterManager.editPlayer` method.
- This replaces the previous sequential `prompt()` dialogs with a more user-friendly single modal interface.