### PR TITLE
I've moved the `matchSaveModal.init()` call from the save button's cl…

### DIFF
--- a/js/modules/app.js
+++ b/js/modules/app.js
@@ -63,6 +63,7 @@ export function initializeApp() {
   bindEventListeners();
   bindModalEvents();
   initializeTooltips();
+  matchSaveModal.init();
 
   // Resume timer if needed
   timerController.resumeFromState();
@@ -126,9 +127,6 @@ function bindEventListeners() {
         notificationManager.warning('Please sign in to save match data to the cloud');
         return;
       }
-
-      // Initialize match save modal
-      matchSaveModal.init();
 
       // Show save match modal
       const team1Name = domCache.get('Team1NameElement')?.textContent || 'Team 1';


### PR DESCRIPTION
…ick event listener to the main `initializeApp` function. This ensures that the modal is only initialized once when the application starts, preventing the creation of multiple modal instances in the DOM.