### PR TITLE
feat: Display match notes in load modal

### DIFF
--- a/js/modules/ui/match-load-modal.js
+++ b/js/modules/ui/match-load-modal.js
@@ -44,6 +44,7 @@ class MatchLoadModal {
           <div>
             <strong>${match.title}</strong>
             <small class="d-block text-muted">${new Date(match.savedAt).toLocaleString()}</small>
+            <p class="mb-0 mt-2">${match.notes || ''}</p>
           </div>
           <button class="btn btn-primary btn-sm">Load</button>
         `;


### PR DESCRIPTION
Updates the match load modal to display the notes for each saved match. This provides more context to you when selecting a match to load.