### PR TITLE
fix: Use Buffer for base64 decoding in Netlify function

### DIFF
--- a/netlify/functions/user-matches.js
+++ b/netlify/functions/user-matches.js
@@ -19,7 +19,7 @@ exports.handler = async function(event, context) {
     
     try {
       // Our token is base64 encoded as userId:timestamp
-      const decoded = atob(token).split(':');
+      const decoded = Buffer.from(token, 'base64').toString('binary').split(':');
       userId = decoded[0];
       const timestamp = decoded[1];
       


### PR DESCRIPTION
The `atob` function is not available in the Node.js environment, which caused the `user-matches` Netlify function to fail when handling admin requests. This commit replaces `atob` with `Buffer.from(token, 'base64').toString('binary')` to ensure correct base64 decoding in the Node.js environment.