### PR TITLE
Style: Reduce height of player attendance buttons

### DIFF
--- a/css/custom-framework.css
+++ b/css/custom-framework.css
@@ -2609,16 +2609,20 @@ body {
 }
 
 /*
- ===== NEW MATCH MODAL - PLAYER ATTENDANCE ===== */
+ ===== NEW MATCH MODAL - PLAYER ATTENDANCE (Compact) ===== */
 .player-card {
     background: var(--bg-card);
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
-    padding: var(--spacing-sm);
+    border: 1px solid var(--border-color);
+    /* Thinner border */
+    border-radius: var(--border-radius-sm);
+    /* Slightly smaller radius */
+    padding: var(--spacing-xs) var(--spacing-sm);
+    /* Reduced padding */
     cursor: pointer;
     transition: all 0.2s ease;
     position: relative;
-    min-height: 60px;
+    min-height: 48px;
+    /* Reduced height */
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -2629,19 +2633,22 @@ body {
     border-color: var(--theme-primary);
     background: rgba(var(--theme-primary-rgb), 0.05);
     transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    /* Softer shadow */
 }
 
 .player-card.selected {
-    border-color: var(--theme-success);
-    background: rgba(var(--theme-success-rgb), 0.1);
-    box-shadow: 0 0 0 1px rgba(var(--theme-success-rgb), 0.2);
+    border-color: var(--success-color);
+    background: rgba(var(--success-color-rgb), 0.1);
+    box-shadow: none;
+    /* Remove shadow when selected */
 }
 
 .player-card .selection-indicator {
     opacity: 0;
-    color: var(--theme-success);
-    font-size: 1.2rem;
+    color: var(--success-color);
+    font-size: 1rem;
+    /* Smaller indicator */
     transition: all 0.2s ease;
     margin-left: auto;
     flex-shrink: 0;
@@ -2649,73 +2656,85 @@ body {
 
 .player-card.selected .selection-indicator {
     opacity: 1;
-    transform: scale(1.1);
+    transform: scale(1);
+    /* No pop effect */
 }
 
 .player-card .badge {
     flex-shrink: 0;
-    min-width: 2rem;
+    min-width: 1.75rem;
+    /* Smaller badge */
     text-align: center;
+    font-size: 0.75rem;
+    /* Smaller font */
+    padding: 0.2rem 0.4rem;
 }
 
 .player-card .fw-medium {
     font-weight: 500;
     color: var(--text-primary);
-    line-height: 1.2;
+    line-height: 1.1;
+    /* Tighter line-height */
+    font-size: 0.875rem;
+    /* Slightly smaller font */
 }
 
 .player-card .text-muted {
-    font-size: 0.875rem;
+    font-size: 0.75rem;
+    /* Smaller font */
     color: var(--text-secondary);
-    line-height: 1.1;
+    line-height: 1;
+    /* Tighter line-height */
 }
 
 /* Mobile optimizations for player cards */
 @media (max-width: 768px) {
     .player-card {
-        padding: var(--spacing-sm) var(--spacing-md);
-        min-height: 56px;
-        margin-bottom: var(--spacing-sm);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        min-height: 44px;
+        /* Reduced height for med screens */
+        margin-bottom: var(--spacing-xs);
     }
 
     .player-card .badge {
-        font-size: 0.875rem;
-        padding: 0.25rem 0.5rem;
-        min-width: 1.75rem;
+        font-size: 0.7rem;
+        padding: 0.2rem 0.35rem;
+        min-width: 1.5rem;
     }
 
     .player-card .fw-medium {
-        font-size: 0.95rem;
+        font-size: 0.85rem;
     }
 
     .player-card .text-muted {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
     }
 
     .player-card .selection-indicator {
-        font-size: 1.1rem;
+        font-size: 0.9rem;
     }
 }
 
 /* Extra small screens */
 @media (max-width: 480px) {
     .player-card {
-        padding: var(--spacing-sm);
-        min-height: 52px;
+        padding: var(--spacing-xs);
+        min-height: 40px;
+        /* Reduced height for small screens */
     }
 
     .player-card .badge {
-        font-size: 0.8rem;
-        padding: 0.2rem 0.4rem;
-        min-width: 1.5rem;
+        font-size: 0.65rem;
+        padding: 0.15rem 0.3rem;
+        min-width: 1.25rem;
     }
 
     .player-card .fw-medium {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
     }
 
     .player-card .text-muted {
-        font-size: 0.75rem;
+        font-size: 0.65rem;
     }
 }
 


### PR DESCRIPTION
This commit adjusts the CSS for the player attendance buttons in the new match modal to make them smaller and more compact.

The following changes were made to `css/custom-framework.css`:
- Reduced the `min-height` of `.player-card` for desktop, tablet, and mobile screen sizes.
- Adjusted padding, border, and font sizes to create a more compact and visually consistent appearance at the new, smaller size.