### PR TITLE
Fix: Correct modal stacking for clear stats confirmation

### DIFF
--- a/js/modules/ui/admin-modal.js
+++ b/js/modules/ui/admin-modal.js
@@ -303,21 +303,7 @@ const init = () => {
     if (clearStatsBtn) {
         clearStatsBtn.addEventListener('click', () => {
             if (clearStatsModalInstance) {
-                // Ensure proper z-index stacking before showing
-                const baseZIndex = 1050;
-                const clearStatsModalElement = document.getElementById('clear-stats-confirm-modal');
-                if (clearStatsModalElement) {
-                    clearStatsModalElement.style.zIndex = baseZIndex + 100;
-                }
                 clearStatsModalInstance.show();
-                
-                // Force recalculate backdrop
-                setTimeout(() => {
-                    const backdrop = document.querySelector('.modal-backdrop:last-child');
-                    if (backdrop) {
-                        backdrop.style.zIndex = baseZIndex + 99;
-                    }
-                }, 0);
             }
         });
     }


### PR DESCRIPTION
Removes unnecessary z-index manipulation on the 'clear stats' confirmation modal. This was causing the modal to appear behind the admin dashboard modal.

By removing the manual z-index adjustments, the application now relies on Bootstrap's default modal stacking behavior, which correctly displays the confirmation modal on top.