### PR TITLE
Fix: Harden admin button visibility logic

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Update visibility based on auth state
     const updateAdminButtonVisibility = async () => {
-      if (authService.isUserAuthenticated()) {
+      const user = authService.getCurrentUser();
+      if (authService.isUserAuthenticated() && user && user.email) {
         try {
           const isAdmin = await authService.isAdmin();
           if (isAdmin) {

--- a/netlify/functions/user-matches.js
+++ b/netlify/functions/user-matches.js
@@ -52,12 +52,12 @@ exports.handler = async function(event, context) {
     const isAdminUser = (userId, userEmail) => {
   
       // Get admin identifiers from environment variables
-      const adminEmails = process.env.ADMIN_EMAILS ? 
-        process.env.ADMIN_EMAILS.split(',').map(email => email.trim().toLowerCase()) : 
+      const adminEmails = process.env.ADMIN_EMAILS ?
+        process.env.ADMIN_EMAILS.split(',').map(email => email.trim().toLowerCase()).filter(Boolean) :
         [];
-      
-      const adminUserIds = process.env.ADMIN_USER_IDS ? 
-        process.env.ADMIN_USER_IDS.split(',').map(id => id.trim()) : 
+
+      const adminUserIds = process.env.ADMIN_USER_IDS ?
+        process.env.ADMIN_USER_IDS.split(',').map(id => id.trim()).filter(Boolean) :
         [];
       
       // SECURITY: If no admin emails/IDs are configured, deny access


### PR DESCRIPTION
This commit introduces a defense-in-depth approach to ensure the admin dashboard button is only visible to authorized admin users.

Frontend:
- In `js/main.js`, the `updateAdminButtonVisibility` function is hardened to verify that a user is authenticated and has a valid email address before making a server-side request to check for admin privileges. This prevents unnecessary API calls and adds a layer of client-side validation.

Backend:
- In the Netlify function `netlify/functions/user-matches.js`, the parsing of `ADMIN_EMAILS` and `ADMIN_USER_IDS` from environment variables is made more robust. By filtering out empty strings, it prevents potential misconfigurations (e.g., trailing commas) from creating security vulnerabilities.