### PR TITLE
feat: Spread out game action buttons vertically

### DIFF
--- a/css/custom-framework.css
+++ b/css/custom-framework.css
@@ -2231,7 +2231,7 @@ body {
     box-shadow: var(--box-shadow-card);
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
+    justify-content: space-evenly;
     flex: 1;
     min-height: 0;
 }
@@ -2291,7 +2291,6 @@ body {
 @media (max-width: 400px) {
     .game-actions-card {
         padding: var(--spacing-sm);
-        gap: var(--spacing-xs);
     }
 
     .action-row {
@@ -2307,7 +2306,6 @@ body {
 @media (max-width: 360px) {
     .game-actions-card {
         padding: var(--spacing-xs);
-        gap: calc(var(--spacing-xs) / 2);
     }
 
     .action-row {
@@ -2323,14 +2321,12 @@ body {
 @media screen and (max-height: 740px) {
     .game-actions-card {
         padding: var(--spacing-sm);
-        gap: var(--spacing-xs);
     }
 }
 
 @media screen and (max-height: 667px) {
     .game-actions-card {
         padding: var(--spacing-xs);
-        gap: calc(var(--spacing-xs) / 2);
     }
 }
 


### PR DESCRIPTION
This change modifies the CSS for the game actions card to dynamically spread the buttons out vertically, filling the available height. It replaces the fixed 'gap' property with 'justify-content: space-evenly' for a more responsive and visually balanced layout.